### PR TITLE
Add date analysis for Created

### DIFF
--- a/usecase/add_created_from_note.go
+++ b/usecase/add_created_from_note.go
@@ -1,0 +1,42 @@
+package usecase
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/ishida722/krapp-go/models"
+)
+
+var datePattern = regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+
+// AddCreatedFromNote parses the note's file name and content to
+// find the first date string (YYYY-MM-DD) and sets it as the
+// Created field in the frontmatter. If the field already exists,
+// the function does nothing. It returns an error when no date
+// string can be found.
+func AddCreatedFromNote(n *models.Note) error {
+	if n == nil {
+		return fmt.Errorf("note is nil")
+	}
+	if n.FrontMatter == nil {
+		n.FrontMatter = models.FrontMatter{}
+	} else if _, ok := n.FrontMatter["Created"]; ok {
+		return nil
+	}
+
+	if n.FilePath != "" {
+		base := filepath.Base(n.FilePath)
+		if m := datePattern.FindString(base); m != "" {
+			n.FrontMatter["Created"] = m
+			return nil
+		}
+	}
+
+	if m := datePattern.FindString(n.Content); m != "" {
+		n.FrontMatter["Created"] = m
+		return nil
+	}
+
+	return fmt.Errorf("date string not found")
+}

--- a/usecase/add_created_from_note_test.go
+++ b/usecase/add_created_from_note_test.go
@@ -1,0 +1,42 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/ishida722/krapp-go/models"
+)
+
+func TestAddCreatedFromNote_FileName(t *testing.T) {
+	note := &models.Note{
+		Content:     "some content",
+		FilePath:    "/notes/2025-06-10-title.md",
+		FrontMatter: models.FrontMatter{},
+	}
+	if err := AddCreatedFromNote(note); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note.FrontMatter["Created"] != "2025-06-10" {
+		t.Errorf("expected Created 2025-06-10, got %v", note.FrontMatter["Created"])
+	}
+}
+
+func TestAddCreatedFromNote_Content(t *testing.T) {
+	note := &models.Note{
+		Content:     "log from 2025-06-11 about something",
+		FilePath:    "note.md",
+		FrontMatter: models.FrontMatter{},
+	}
+	if err := AddCreatedFromNote(note); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if note.FrontMatter["Created"] != "2025-06-11" {
+		t.Errorf("expected Created 2025-06-11, got %v", note.FrontMatter["Created"])
+	}
+}
+
+func TestAddCreatedFromNote_NoDate(t *testing.T) {
+	note := &models.Note{Content: "no date here"}
+	if err := AddCreatedFromNote(note); err == nil {
+		t.Error("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add `AddCreatedFromNote` usecase
- add unit tests for `AddCreatedFromNote`

## Testing
- `go test ./...` *(fails: Forbidden for storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684fe6885300832a96d8abf232b703c7